### PR TITLE
Feat debug graphs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,5 +24,5 @@ export default defineConfig([
     },
   },
   reactRefresh.configs.recommended,
-  globalIgnores(["dist/*"]),
+  globalIgnores(["dist/*", "out/*"]),
 ]);

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -5,7 +5,7 @@ const getDevURL = () => {
     return null;
   }
   let url = import.meta.env.VITE_SERVER_URL;
-  if (!url.startsWith("http://") || !url.startsWith("https://")) {
+  if (!url.startsWith("http://") && !url.startsWith("https://")) {
     url = `http://${url}`;
   }
   return url;

--- a/src/components/DebugDataChart.tsx
+++ b/src/components/DebugDataChart.tsx
@@ -1,0 +1,133 @@
+import { useImperativeHandle, forwardRef, useState } from "react";
+import ReactECharts from "echarts-for-react";
+import * as echarts from "echarts";
+
+type DebugDataChartProps = {
+  maxPoints?: number; // Optional buffer size. If not set, data is stored indefinitely.
+};
+export type SensorDataPoint = Record<string, number | string>;
+
+export type DebugDataChartRef = {
+  clearData: () => void;
+  pushData: (dataPoint: SensorDataPoint) => void;
+};
+const contrastColors = [
+  "#e6194b",
+  "#3cb44b",
+  "#ffe119",
+  "#4363d8",
+  "#f58231",
+  "#911eb4",
+  "#46f0f0",
+  "#f032e6",
+  "#bcf60c",
+  "#fabebe",
+  "#008080",
+  "#e6beff",
+  "#9a6324",
+  "#fffac8",
+  "#800000",
+];
+
+export const DebugDataChart = forwardRef<
+  DebugDataChartRef,
+  DebugDataChartProps
+>(({ maxPoints = 0 }, ref) => {
+  const [seriesData, setSeriesData] = useState<
+    Record<string, (string | number)[]>
+  >({});
+  const [timeStamps, setTimeStamps] = useState<string[]>([]);
+
+  useImperativeHandle(ref, () => ({
+    clearData: () => {
+      setSeriesData({});
+      setTimeStamps([]);
+    },
+    pushData(dataPoint: SensorDataPoint) {
+      const now = new Date().toLocaleTimeString();
+
+      setTimeStamps((prev) => {
+        const newTimestamps = [...prev, now];
+        return maxPoints > 0 ? newTimestamps.slice(-maxPoints) : newTimestamps;
+      });
+
+      setSeriesData((prevData) => {
+        const newData: Record<string, (number | string)[]> = { ...prevData };
+
+        Object.entries(dataPoint).forEach(([key, value]) => {
+          const series = newData[key] || [];
+          const updated = [...series, value];
+          newData[key] = maxPoints > 0 ? updated.slice(-maxPoints) : updated;
+        });
+
+        // Ensure missing series (not in current dataPoint) also maintain length
+        Object.keys(prevData).forEach((key) => {
+          if (!(key in dataPoint)) {
+            const padded = [...prevData[key], NaN]; // Keep timeline alignment
+            newData[key] = maxPoints > 0 ? padded.slice(-maxPoints) : padded;
+          }
+        });
+
+        return newData;
+      });
+    },
+  }));
+
+  const options: echarts.EChartsOption = {
+    animation: false,
+    backgroundColor: "#272727", // dark background
+
+    xAxis: {
+      type: "category",
+      data: timeStamps,
+      boundaryGap: false,
+      axisLine: { lineStyle: { color: "#ccc" } },
+      axisLabel: { color: "#ccc" },
+      splitLine: { show: true, lineStyle: { color: "#444" } },
+    },
+    yAxis: {
+      type: "value",
+      scale: true,
+      axisLine: { lineStyle: { color: "#ccc" } },
+      axisLabel: { color: "#ccc" },
+      splitLine: { show: true, lineStyle: { color: "#444" } },
+    },
+    series: Object.entries(seriesData).map(([key, values], index) => ({
+      name: key,
+      type: "line",
+      data: values,
+      showSymbol: false,
+      connectNulls: true,
+      lineStyle: {
+        width: 2,
+      },
+      color: contrastColors[index % contrastColors.length], // Custom color palette
+    })),
+    tooltip: {
+      trigger: "axis",
+      backgroundColor: "#333",
+      textStyle: { color: "#fff" },
+    },
+    legend: {
+      data: Object.keys(seriesData),
+      textStyle: { color: "#fff" },
+    },
+    grid: {
+      left: "3%",
+      right: "4%",
+      bottom: "3%",
+      containLabel: true,
+    },
+  };
+
+  return (
+    <ReactECharts
+      className="flex-1 2xl:min-w-auto sm:min-w-[550px] sm:w-auto min-w-full w-full"
+      option={options}
+      notMerge={true}
+      lazyUpdate={true}
+      opts={{ renderer: "canvas" }}
+    />
+  );
+});
+DebugDataChart.displayName = "DebugDataChart";


### PR DESCRIPTION
We are adding the debug graphs which used to live in /debug in the backend with properly styled and self-updating echarts

<img width="2207" height="1377" alt="image" src="https://github.com/user-attachments/assets/a2365e1b-9c4b-470d-9bef-4a0736b43c9e" />
